### PR TITLE
Initialize error variables before using them

### DIFF
--- a/esp8266/client_mpu_error/client_mpu_error.ino
+++ b/esp8266/client_mpu_error/client_mpu_error.ino
@@ -32,7 +32,7 @@ void calculate_IMU_error(int MPU)
   // Initialize variables
   float AccX, AccY, AccZ;
   float GyroX, GyroY, GyroZ;
-  float AccErrorX, AccErrorY, GyroErrorX, GyroErrorY, GyroErrorZ;
+  float AccErrorX = 0, AccErrorY = 0, GyroErrorX = 0, GyroErrorY = 0, GyroErrorZ = 0;
   int c = 0;
   int testTimes = 800;
   // Setup wire for the current mpu


### PR DESCRIPTION
Automatic variables are not implicitly initialized to zero: they must be explicitly initialized if their initial value is going to be used. This pull request adds the required initialization to the “Error” variables in client\_mpu\_error. It fixes this compiler warning:

```c++
'AccErrorX' may be used uninitialized in this function
```

and similar warnings for `AccErrorY`, `GyroErrorX`, `GyroErrorY` and `GyroErrorZ`.

Note that failure to initialize the variables can lead to incorrect readings. If these wrong readings are then used in client\_mpu, the erroneous gyro errors would induce a drift in the computed pitch and roll angles, as seen in [this question](https://arduino.stackexchange.com/questions/88397).